### PR TITLE
Correct Python3 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python3',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development',
         'Topic :: Utilities',
     ],


### PR DESCRIPTION
PyPi didn't accept the previous Python3 classifier, according to https://pypi.org/pypi?%3Aaction=list_classifiers this is the right way: `Programming Language :: Python :: 3`