### PR TITLE
Also build source archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test: clean
 .PHONY: dist
 dist: clean
 	@echo ">> Building"
-	@python setup.py bdist_wheel
+	@python setup.py sdist bdist_wheel
 	@echo "!! Build ready"
 
 .PHONY: docs


### PR DESCRIPTION
According to the Python packaging tutorial
(https://packaging.python.org/tutorials/packaging-projects/) it is
better to include both the source archive and the wheel in the
distribution for compatibility reasons.